### PR TITLE
Recent Loki versions can't parse integer labels

### DIFF
--- a/Drivers/Loki/LokiLogLogger.groovy
+++ b/Drivers/Loki/LokiLogLogger.groovy
@@ -15,7 +15,7 @@
 import groovy.transform.Field
 import groovy.json.JsonSlurper
 
-@Field String VERSION = "1.0.3"
+@Field String VERSION = "1.0.4"
 
 @Field List<String> LOG_LEVELS = ["error", "warn", "info", "debug", "trace"]
 @Field String DEFAULT_LOG_LEVEL = LOG_LEVELS[1]
@@ -99,7 +99,7 @@ void parse(String description) {
                       event_type: 'logs',
                       event_source: (descData?.type?.trim() ?: 'None'),
                       level: (descData?.level?.trim() ?: 'None'),
-                      device_id: descData.id,
+                      device_id: descData.id.toString(),
                       device_id_net: 'None',
                       device_type: (descData?.type?.trim() ?: 'None'),
                       device_name: (descData?.name?.trim() ?: 'None'),

--- a/Drivers/Loki/LokiLogLogger.json
+++ b/Drivers/Loki/LokiLogLogger.json
@@ -2,7 +2,7 @@
   "packageName": "LokiLogLogger",
   "minimumHEVersion": "2.2.3",
   "author": "Sebastian YEPES FERNANDEZ",
-  "dateReleased": "2020-10-28",
+  "dateReleased": "2023-11-15",
   "documentationLink": "",
   "communityLink": "",
   "licenseFile": "https://github.com/syepes/Hubitat#license",
@@ -12,7 +12,7 @@
       "name": "LokiLogLogger",
       "namespace": "syepes",
       "location": "https://raw.githubusercontent.com/syepes/Hubitat/master/Drivers/Loki/LokiLogLogger.groovy",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "required": true
     }
   ]


### PR DESCRIPTION
```descData.id``` is an integer but the ```/loki/api/v1/push``` endpoint in recent Loki versions (somewhere between 2.6 and 2.9) became more stringent about accepting string labels only. This caused the "```Value is string, but can't find closing```"  error (from [their new JSON parser](https://github.com/buger/jsonparser), I wager.

So I am simply transforming it into a string.