### PR TITLE
Updater keeps updating

### DIFF
--- a/Apps/Netatmo/Netatmo - Velux.json
+++ b/Apps/Netatmo/Netatmo - Velux.json
@@ -58,7 +58,7 @@
       "name": "Netatmo - Velux - Blind",
       "namespace": "syepes",
       "location": "https://raw.githubusercontent.com/syepes/Hubitat/master/Drivers/Netatmo/Netatmo%20-%20Velux%20-%20Blind.groovy",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "required": true
     },
     {

--- a/Drivers/Loki/LokiLogLogger.groovy
+++ b/Drivers/Loki/LokiLogLogger.groovy
@@ -15,7 +15,7 @@
 import groovy.transform.Field
 import groovy.json.JsonSlurper
 
-@Field String VERSION = "1.0.3"
+@Field String VERSION = "1.0.4"
 
 @Field List<String> LOG_LEVELS = ["error", "warn", "info", "debug", "trace"]
 @Field String DEFAULT_LOG_LEVEL = LOG_LEVELS[1]
@@ -99,7 +99,7 @@ void parse(String description) {
                       event_type: 'logs',
                       event_source: (descData?.type?.trim() ?: 'None'),
                       level: (descData?.level?.trim() ?: 'None'),
-                      device_id: descData.id,
+                      device_id: descData.id.toString(),
                       device_id_net: 'None',
                       device_type: (descData?.type?.trim() ?: 'None'),
                       device_name: (descData?.name?.trim() ?: 'None'),

--- a/Drivers/Loki/LokiLogLogger.json
+++ b/Drivers/Loki/LokiLogLogger.json
@@ -2,7 +2,7 @@
   "packageName": "LokiLogLogger",
   "minimumHEVersion": "2.2.3",
   "author": "Sebastian YEPES FERNANDEZ",
-  "dateReleased": "2020-10-28",
+  "dateReleased": "2023-11-15",
   "documentationLink": "",
   "communityLink": "",
   "licenseFile": "https://github.com/syepes/Hubitat#license",
@@ -12,7 +12,7 @@
       "name": "LokiLogLogger",
       "namespace": "syepes",
       "location": "https://raw.githubusercontent.com/syepes/Hubitat/master/Drivers/Loki/LokiLogLogger.groovy",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "required": true
     }
   ]


### PR DESCRIPTION
This could fix https://github.com/syepes/Hubitat/issues/8

I don't know much about HPM but I saw a discrepancy between what the JSON advertises (Blind at 1.0.1) and what the [URL](https://raw.githubusercontent.com/syepes/Hubitat/master/Drivers/Netatmo/Netatmo%20-%20Velux%20-%20Blind.groovy) points to. I imagine this causes HPM to think it doesn't have the latest (1.0.1) of that driver but always downloads 1.0.0

```
    {
      "name": "Netatmo - Velux - Blind",
      "namespace": "syepes",
      "location": "https://raw.githubusercontent.com/syepes/Hubitat/master/Drivers/Netatmo/Netatmo%20-%20Velux%20-%20Blind.groovy",
      "version": "1.0.1",
      "required": true
    },
```

doesn't match

```@Field String VERSION = "1.0.0"``` for that file